### PR TITLE
ci: add eslint lint step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,10 @@ jobs:
 
       - uses: borales/actions-yarn@v3.0.0
         with:
+          cmd: lint
+
+      - uses: borales/actions-yarn@v3.0.0
+        with:
           cmd: build -- --base /${{ github.event.repository.name }}/
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
**Description**

update .github/workflows/deploy.yml so the deployment job runs yarn lint right after dependencies install
ensure the build/deploy stages only happen when ESLint passes, preventing bad deployments

**Testing**

npm run lint (fails locally because dependencies aren’t installed in the current environment)

Fixes Issues #1 