### PR TITLE
ci: lint pull requests before merge

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,19 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: install
+
+      - uses: borales/actions-yarn@v3.0.0
+        with:
+          cmd: lint


### PR DESCRIPTION
**Description**

add a PR Validation GitHub Actions workflow triggered on pull_request against master
run yarn lint after dependency installation so ESLint failures block merges

**Testing**

npm run lint (requires dependencies; not executed locally in this environment)

Fixes Issue #2 